### PR TITLE
typo error

### DIFF
--- a/guide/linux_gsg/linux_gsg.html
+++ b/guide/linux_gsg/linux_gsg.html
@@ -107,7 +107,7 @@ use the sample application.</p></li>
 <section id="system-requirements-and-building-cndp">
 <span id="building-cndp"></span><h1><span class="section-number">2. </span>System Requirements and Building CNDP<a class="headerlink" href="#system-requirements-and-building-cndp" title="Permalink to this headline">¶</a></h1>
 <p>This chapter describes the packages required to compile CNDP. It assumes you are building on an
-Ubuntu 21.04 host.</p>
+Ubuntu 20.04 host.</p>
 <p>To bypass manual installation, use the ansible scripts provided by CNDP in the section:
 <a class="reference internal" href="#installation-of-cndp-requirements-using-ansible">Installation of CNDP requirements using Ansible</a>.</p>
 <section id="bios-settings">


### PR DESCRIPTION
### Typo Error

`Ubuntu 21.04` ---> `Ubuntu 20.04`